### PR TITLE
窗口缩放时滚动

### DIFF
--- a/frontend/src/components/ChatRenderer/index.vue
+++ b/frontend/src/components/ChatRenderer/index.vue
@@ -65,7 +65,11 @@ export default {
     this.styleElement.innerText = this.css
     this.scrollToBottom()
   },
+  created() {
+    window.addEventListener('resize', this.scrollToBottom)
+  },
   beforeDestroy() {
+    window.removeEventListener('resize', this.scrollToBottom)
     document.head.removeChild(this.styleElement)
   },
   updated() {


### PR DESCRIPTION
在窗口缩放时自动滚动到最下方
避免了以下尴尬的情况

样式生成器：
<img width="482" alt="image" src="https://user-images.githubusercontent.com/12656264/61080866-44b5fa00-a426-11e9-88b3-853d318a00b8.png">

但是我并不清楚这个改动是否会对OBS使用造成影响。。。