### PR TITLE
更换获取头像的接口并加入Wbi鉴权，降低风控概率

### DIFF
--- a/services/avatar.py
+++ b/services/avatar.py
@@ -13,6 +13,7 @@ import config
 import models.bilibili as bl_models
 import models.database
 import utils.request
+from .wbi import transform_params
 
 logger = logging.getLogger(__name__)
 
@@ -147,20 +148,19 @@ async def _get_avatar_url_from_web_coroutine(user_id, future):
 
 async def _do_get_avatar_url_from_web(user_id):
     try:
+        params={
+                'mid': user_id
+            }
+        signed_params = await transform_params(params)
         async with utils.request.http_session.get(
-            'https://api.bilibili.com/x/space/acc/info',
+            'https://api.bilibili.com/x/space/wbi/acc/info',
             headers={
                 **utils.request.BILIBILI_COMMON_HEADERS,
                 'Origin': 'https://space.bilibili.com',
                 'Referer': f'https://space.bilibili.com/{user_id}/'
             },
             cookies=utils.request.BILIBILI_COMMON_COOKIES,
-            params={
-                'mid': user_id,
-                'token': '',
-                'platform': 'web',
-                'jsonp': 'jsonp'
-            }
+            params = signed_params
         ) as r:
             if r.status != 200:
                 logger.warning('Failed to fetch avatar: status=%d %s uid=%d', r.status, r.reason, user_id)

--- a/services/wbi.py
+++ b/services/wbi.py
@@ -1,0 +1,63 @@
+from functools import reduce
+from hashlib import md5
+import urllib.parse
+import time
+import requests
+
+
+mixinKeyEncTab = [
+    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49,
+    33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40,
+    61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11,
+    36, 20, 34, 44, 52
+]
+
+
+def get_mixin_key(orig: str):
+    """对 imgKey 和 subKey 进行字符顺序打乱编码"""
+    return reduce(lambda s, i: s + orig[i], mixinKeyEncTab, '')[:32]
+
+
+def enc_wbi(params: dict, img_key: str, sub_key: str):
+    """为请求参数进行 wbi 签名"""
+    mixin_key = get_mixin_key(img_key + sub_key)
+    curr_time = round(time.time())
+    params['wts'] = curr_time                                   # 添加 wts 字段
+    params = dict(sorted(params.items()))                       # 按照 key 重排参数
+    # 过滤 value 中的 "!'()*" 字符
+    params = {
+        k: ''.join(filter(lambda x: x not in "!'()*", str(v)))
+        for k, v
+        in params.items()
+    }
+    query = urllib.parse.urlencode(params)                      # 序列化参数
+    wbi_sign = md5((query + mixin_key).encode()).hexdigest()    # 计算 w_rid
+    params['w_rid'] = wbi_sign
+    return params
+
+
+def get_wbi_keys() -> tuple[str, str]:
+    """获取最新的 img_key 和 sub_key"""
+    resp = requests.get('https://api.bilibili.com/x/web-interface/nav')
+    resp.raise_for_status()
+    json_content = resp.json()
+    img_url: str = json_content['data']['wbi_img']['img_url']
+    sub_url: str = json_content['data']['wbi_img']['sub_url']
+    img_key = img_url.rsplit('/', 1)[1].split('.')[0]
+    sub_key = sub_url.rsplit('/', 1)[1].split('.')[0]
+    return img_key, sub_key
+
+
+async def transform_params(params: dict):
+    img_key, sub_key = get_wbi_keys()
+    signed_params = enc_wbi(
+        params=params,
+        img_key=img_key,
+        sub_key=sub_key
+    )
+    return signed_params
+
+
+__all__ = [
+    'transform_params'
+]


### PR DESCRIPTION
把Api从 `https://api.bilibili.com/x/space/acc/info` 更换为 `https://api.bilibili.com/x/space/wbi/acc/info` 以解决B站风控问题，wbi签名代码来源：https://github.com/SocialSisterYi/bilibili-API-collect/issues/631#issuecomment-1558747661