### PR TITLE
修复一定时间后弹幕的用户名头像打码

### DIFF
--- a/frontend/src/api/chat/ChatClientDirect/index.js
+++ b/frontend/src/api/chat/ChatClientDirect/index.js
@@ -110,7 +110,7 @@ export default class ChatClientDirect {
       uid: this.roomOwnerUid,
       roomid: this.roomId,
       protover: 3,
-      platform: 'web',
+      platform: 'danmuji',
       type: 2
     }
     this.websocket.send(this.makePacket(authParams, OP_AUTH))

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ routes = [
 
     (r'/api/chat', api.chat.ChatHandler),
     (r'/api/room_info', api.chat.RoomInfoHandler),
+    (r'/api/danmu_info', api.chat.DanmuInfoHandler),
     (r'/api/avatar_url', api.chat.AvatarHandler),
 
     (rf'{api.main.EMOTICON_BASE_URL}/(.*)', tornado.web.StaticFileHandler, {'path': api.main.EMOTICON_UPLOAD_PATH}),


### PR DESCRIPTION
根据 [弹幕姬](https://github.com/copyliu/bililive_dm/blob/master/BiliDMLib/DanmakuLoader.cs#L400) 的认证数据，将相应行的 platform 从 `'web'` 更改为 `'danmuji'` 后，挂机一小时后发现已经没有打码的现象。

另外 弹幕姬 内的认证步骤存在的 key 和 host_list 的获取也有在该项目尝试，但似乎只修改 platform 即可避免打码。

目前改为 `'danmuji'` 的方法没有经过更长时间的测试，但 弹幕姬 的使用中没有出现过问题，请酌情考虑。