### PR TITLE
修复 Web client 初始化 UID

### DIFF
--- a/services/chat.py
+++ b/services/chat.py
@@ -120,7 +120,6 @@ class WebLiveClient(blivedm.BLiveClient):
         assert room_key.type == RoomKeyType.ROOM_ID
         super().__init__(
             room_key.value,
-            uid=0,
             session=utils.request.http_session,
             heartbeat_interval=self.HEARTBEAT_INTERVAL,
         )


### PR DESCRIPTION
创建 web client 的时候，uid 被直接设置为 0。这样会跳过 blivedm 的 [UID 初始化](https://github.com/xfgryujk/blivedm/blob/b1d066b59fabe106ce70a822e9f6e6ba29242519/blivedm/clients/web.py#L90)部分。这里的 uid 最好使用默认值 None，初始化交给 blivedm 那边。我看 blivedm 的实现已经很完善了，会通过 HTTP session 尝试获取 UID，获取不到时 fallback 为 0。

在目前的版本中，由于并没有给 `utils.request.http_session` 添加任何 cookie，最终结果确实没有任何影响。但是如果未来引入对 cookie 的设置，最好还是修改一下以保证正确。谢谢！