### PR TITLE
翻译接口适配本地部署的 llama.cpp + gemma4

### DIFF
--- a/services/translate.py
+++ b/services/translate.py
@@ -493,6 +493,7 @@ class OpenAiApi(TranslateProvider):
             ],
             'model': model,
             'thinking': {'type': 'disabled'},
+            'chat_template_kwargs': {'enable_thinking': False},
             # 'reasoning_effort': 'none',  # 很多模型不支持none值
             'max_tokens': max_tokens,
             'stream': False,


### PR DESCRIPTION
如果开启了翻译，在本地部署llama.cpp + gemma4 的场景，python脚本中关闭 reasoning 的功能会失效，表现为无法使用，根因是输出token超出限制。
故在调用接口的地方新增llama.cpp + gemma4配合使用时可以识别的开关。

P.S. 在不支持思考的例如 混元MT2-1.8B-1.25bit 上不会复现